### PR TITLE
fixing strict mkdocs warnings

### DIFF
--- a/docs/parts/histfactory.md
+++ b/docs/parts/histfactory.md
@@ -3,13 +3,11 @@ bibliography: ./hs3.bib
 ---
 
 
-HistFactory [@hf] is a language to describe statistical models consisting only of "histograms" (which is used interchangeably with "step-functions" in this context). Each HistFactory distribution describes one "channel" or "region" of a binned measurement, containing a stack of "samples", i. e.&nbsp;binned distributions sharing the same binning (step-functions describing the signal or background of a measurement). Such a HistFactory model is shown in 
-Figure [1](#fig:hf-example){reference-type="ref" reference="fig:hf-example"}. Each of the contributions may be subject to `modifiers`. 
-![A binned statistical model describing a High Energy Physics measurement, in this case of the $H\to4\ell$ process by the ATLAS collaboration [@atlashzz]. Three different sample (blue, red, violet) 
-are considered.](images/hf-example.pdf){#fig:hf-example width=".6\%"} 
+HistFactory [@hf] is a language to describe statistical models consisting only of "histograms" (which is used interchangeably with "step-functions" in this context). Each HistFactory distribution describes one "channel" or "region" of a binned measurement, containing a stack of "samples", i. e.&nbsp;binned distributions sharing the same binning (step-functions describing the signal or background of a measurement). Such a HistFactory model is shown in Figure [1](#fig:hf-example){reference-type="ref" reference="fig:hf-example"} (originally from  [@atlashzz]). Each of the contributions may be subject to `modifiers`. 
+
+![A binned statistical model describing a High Energy Physics measurement, in this case of the $H\to4\ell$ process by the ATLAS collaboration. Three different sample (blue, red, violet) are considered.](/images/hf-example.pdf){#fig:hf-example width=".6\%"} 
+
 The prediction for a binned region is given as 
-
-
 
 $$
 \begin{aligned} \lambda(x)=\sum_{s\in\text{samples}} \left[ \left( d_s(x) + \sum_{\delta\in M_{\delta}} \delta(x,\theta_\delta) \right) \prod_{\kappa\in M_\kappa} \kappa(x,\theta_\kappa)   \right] \end{aligned} 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ plugins:
   - bibtex:
       bib_file: docs/hs3.bib
       bib_by_default: false
-      cite_inline: true
+      enable_inline_citations: true 
 
 nav:
   - Home: main.md


### PR DESCRIPTION
Mkdocs currently fails in strict mode, attempting to fix this.