### PR TITLE
making markdown detectable to linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable=true


### PR DESCRIPTION
add a gitattributes file to make sure linguist treates the repo correctly