### PR TITLE
Distributions typo fixes, and note multidimensionality of the Barlow-Beeston x variable

### DIFF
--- a/docs/chapters/2.1.1_fundamental_distributions.md
+++ b/docs/chapters/2.1.1_fundamental_distributions.md
@@ -31,7 +31,7 @@ and describes the ARGUS background shape.
 
 #### Continued Poisson distribution
 
-The of a continued Poisson distribution of the variable $x$ is defined as 
+The continued Poisson distribution of the variable $x$ is defined as 
 
 $$
 \begin{aligned} \text{ContinuedPoissonPdf}(x, \lambda) = \frac{1}{\ensuremath{\mathcal{M}}} \exp\left(x \cdot \ln \lambda - \lambda - \ln \Gamma(x+1)\right), \end{aligned} 
@@ -133,6 +133,7 @@ $$
 -   `x`: name of the variable $x$ 
 -   `mean`: value or name of the parameter used as mean value $\mu$ 
 -   `sigma`: value or name of the parameter encoding the standard     deviation $\sigma$. 
+
 #### Log-Normal distribution
 
 The log-normal distribution is defined as 
@@ -187,7 +188,7 @@ $$
 This section contains multivariate fundamental distributions. They may
 refer to functions, parameters and more than one variable.
 
-#### Barlow-Besston-Lite Constraint distribution
+#### Barlow-Beeston-Lite Constraint distribution
 
 This distribution represents a product of Poisson distributions
 defining the statistical uncertainties of the histogram templates
@@ -201,7 +202,7 @@ $$
 
 -   `name`: custom unique string 
 -   `type`: `barlow_beeston_lite_poisson_constraint_dist` 
--   `x`: name of the variable $x$ 
+-   `x`: array of names of the variables $x_i$. This also includes mixed arrays of values and names. 
 -   `expected`: array of central values $\tau_i$ 
 
 #### Multivariate normal distribution


### PR DESCRIPTION
Just a few fixes to the distribution descriptions.