### PR TITLE
More typo fixes in the distributions section

### DIFF
--- a/docs/chapters/2.1.1_fundamental_distributions.md
+++ b/docs/chapters/2.1.1_fundamental_distributions.md
@@ -31,7 +31,7 @@ and describes the ARGUS background shape.
 
 #### Continued Poisson distribution
 
-The of a continued Poisson distribution of the variable $x$ is defined as 
+The continued Poisson distribution of the variable $x$ is defined as 
 
 $$
 \begin{aligned} \text{ContinuedPoissonPdf}(x, \lambda) = \frac{1}{\ensuremath{\mathcal{M}}} \exp\left(x \cdot \ln \lambda - \lambda - \ln \Gamma(x+1)\right), \end{aligned} 
@@ -133,6 +133,7 @@ $$
 -   `x`: name of the variable $x$ 
 -   `mean`: value or name of the parameter used as mean value $\mu$ 
 -   `sigma`: value or name of the parameter encoding the standard     deviation $\sigma$. 
+
 #### Log-Normal distribution
 
 The log-normal distribution is defined as 
@@ -187,7 +188,7 @@ $$
 This section contains multivariate fundamental distributions. They may
 refer to functions, parameters and more than one variable.
 
-#### Barlow-Besston-Lite Constraint distribution
+#### Barlow-Beeston-Lite Constraint distribution
 
 This distribution represents a product of Poisson distributions
 defining the statistical uncertainties of the histogram templates
@@ -201,7 +202,7 @@ $$
 
 -   `name`: custom unique string 
 -   `type`: `barlow_beeston_lite_poisson_constraint_dist` 
--   `x`: name of the variable $x$ 
+-   `x`: array of names of the variables $x_i$. This also includes mixed arrays of values and names. 
 -   `expected`: array of central values $\tau_i$ 
 
 #### Multivariate normal distribution

--- a/docs/chapters/2.1.1_fundamental_distributions.md
+++ b/docs/chapters/2.1.1_fundamental_distributions.md
@@ -45,7 +45,7 @@ reference="dist:poisson"}), but can accept non-integer values for
 $x$. Notably, the differences between the two might be significant for
 small values of $x$ (below x). Nevertheless, the distribution is
 useful to deal with datasets with non-integer event counts, such as
-asimov datasets [@asymptotics].
+Asimov datasets [@asymptotics].
 
 -   `name`: custom unique string 
 -   `type`: `poisson_dist` 
@@ -55,7 +55,7 @@ asimov datasets [@asymptotics].
 
 #### Uniform distribution
 
-The of a continuous uniform distribution is defined as: 
+The continuous uniform distribution is defined as: 
 
 
 $$
@@ -68,11 +68,11 @@ $$
 -   `type`: `uniform_dist` 
 -   `x`: name of the variable $x$ 
 
-#### CrystalBall distribution
+#### Crystal Ball distribution
 
-The generalized Asymmetrical Double-Sided Crystall Ball line shape,
+The generalized Asymmetrical Double-Sided Crystal Ball line shape,
 composed of a Gaussian distribution at the core, connected with two
-powerlaw distributions describing the lower and upper tails, given by
+power-law distributions describing the lower and upper tails, given by
 
 $$
 \begin{aligned} \text{CrystalBallPdf}(m;m_0,\sigma,\alpha_L,n_L,\alpha_R,n_R) = \frac{1}{\ensuremath{\mathcal{M}}} \begin{cases} A_L \cdot (B_L - \frac{m - m_0}{\sigma_L})^{-n_L}, & \mbox{for }\frac{m - m_0}{\sigma_L} < -\alpha_L \\ \exp \left( - \frac{1}{2} \cdot \left[ \frac{m - m_0}{\sigma_L} \right]^2 \right), & \mbox{for }\frac{m - m_0}{\sigma_L} \leq 0 \\ \exp \left( - \frac{1}{2} \cdot \left[ \frac{m - m_0}{\sigma_R} \right]^2 \right), & \mbox{for }\frac{m - m_0}{\sigma_R} \leq \alpha_R \\ A_R \cdot (B_R + \frac{m - m_0}{\sigma_R})^{-n_R}, & \mbox{otherwise}, \\ \end{cases} \end{aligned} 
@@ -223,15 +223,19 @@ with $\boldsymbol\Sigma \in \mathbb{R}^{k\times k}$ being positive-definite.
 -   `mean`: array of length $k$ of values or names of the parameters     used as mean values $\boldsymbol\mu$ 
 -   `covariances`: an array comprised of $k$ sub-arrays, each of which     is also of length $k$, designed to store values or names of the     entries of the covariance matrix $\boldsymbol\Sigma$. In general,     the covariance matrix $\boldsymbol\Sigma$ [must]{.smallcaps} be     symmetric and positive semi-definite. 
 
+
+#### Generic distribution
+
 *Note: Users should prefer the specific distributions defined in this standard over generic distributions where possible, as implementations of these will typically be more optimized. Generic distributions should only be used if no equivalent specific distribution is defined.* 
 
-A generic distribution is defined by an expression that respresents the PDF of the distribution in respect to the Lebesque measure. The expression must be a valid HS<sup>3</sup>-expression string (see Section 
+A generic distribution is defined by an expression that represents the PDF of the distribution in respect to the Lebesgue measure. The expression must be a valid HS<sup>3</sup>-expression string (see Section 
 [Generic Expressions](#sec:generic_expression){reference-type="ref" reference="sec:generic_expression"}). 
 
 -   `name`: custom string 
 -   `type`: `generic_dist` 
 -   `expression`: a string with a generic mathematical expression.     Simple mathematical syntax common to most programming languages     should be used here, such as `x-2*y+z`. The arguments `x`, `y` and     `z` in this example [must]{.smallcaps} be parameters, functions or     variables. 
-The distribution is normalized by the implementation, a normalization term [should not]{.smallcaps} be included in the expression. If the expression results in a negative value, the behavior is undefined. 
+The distribution is normalized by the implementation, so a normalization term [should not]{.smallcaps} be included in the expression. If the expression results in a negative value, the behavior is undefined. 
+
 
 #### HistFactory distribution
 
@@ -240,7 +244,7 @@ The distribution is normalized by the implementation, a normalization term [shou
 
 #### Relativistic Breit-Wigner distribution
 
-The relativistic Breit-Wigner distribution describes the lineshape of a resonance studies in the mass spectrum of two particle system. It is assumed that the resonance can decay into a list of channels. 
+The relativistic Breit-Wigner distribution describes the line-shape of a resonance in the mass spectrum of a two-particle system. It is assumed that the resonance can decay into a list of channels. 
 
 The first channel in the list indicates the system for which mass
 distribution is modelled.


### PR DESCRIPTION
Just cosmetics, and restoring the missing heading for the generic-distributions section.