### PR TITLE
Conversion to typst

### DIFF
--- a/docs/chapters/1_introduction.typ
+++ b/docs/chapters/1_introduction.typ
@@ -1,0 +1,96 @@
+#import "/docs/hs3-defs.typ": sc
+// Chapter 1: Introduction
+
+= Introduction <sec:introduction>
+
+_This section is non-normative._
+
+It is widely agreed upon that the publication of likelihood models from high energy physics experiments is imperative for the preservation and public access to these results. Detailed arguments have been made elsewhere already @Cranmer_2022. This document sets out to provide a standardized format to publish and archive statistical models of any size and across a wide range of mathematical formalisms in a way that is readable by both humans and machines.
+With the introduction of `pyhf` @pyhf @pyhf-joss, a `JSON` format for likelihood serialization has been put forward. However, an interoperable format that encompasses likelihoods with a scope beyond stacks of binned histograms was lacking. With the release of `ROOT` 6.26/00 @root and the experimental `RooJSONFactoryWSTool` therein, this gap has now been filled.
+This document sets out to document the syntax and features of the Statistics Serialization Standard (HS#super[3]) for likelihoods and statistical models in general, as to be adopted by any HS#super[3]-compatible statistics framework. The examples in this document employ the `JSON` notation, but are intended to encompass also representations as `YAML` or `TOML`.
+
+== How to use this document
+
+Developers of statistical toolkits are invited to specifically refer to versions of this document relating to the support of this standard in their respective implementations.
+Please note that this document as well as the HS#super[3] standard are still in development and can still undergo minor and major changes in the future. This document describes the syntax of HS#super[3] v0.2.9.
+
+== Statistical semantics of HS#super[3] <sec:hs3-semantics>
+
+=== Statistical models, probability distributions and parameters <sec:models-and-parameters>
+
+HS#super[3] takes a "forward-modelling" approach throughout: a statistical model $m$ maps a space $Theta$ of free parameters $theta$ to a space of probability distributions that describe the possible outcomes of a specific experiment. For any given parameters $theta$, the model returns a concrete probability distribution $m(theta)$. Observed data $x$ is then treated as random variate, presumed to be drawn from the model: $x tilde m(theta)$.
+
+Parameters in HS#super[3] are always named, so semantically the elements of a parameter space $Theta$ are named tuples $theta$ (meaning tuples in which every entry has a name). Even if there is only a single free parameter, $theta$ should be thought of as a single-entry named tuple. In the current version of this standard, parameter tuples must be flat and only consist of real numbers, vector-valued or nested entries are not supported yet. Future versions of the standard will likely be less restrictive, especially with respect to discrete or vector-valued parameters. Parameter domains defined as part of this standard may be of various types, even though the current version only supports product domains. Future versions are likely to be less restrictive in this regard.
+
+Mathematically and computationally, it is often convenient to treat parameters as flat real-valued vectors instead of named tuples, it is the responsibility of the implementation to map between these different views of parameters when and where necessary.
+
+Probability distributions in HS#super[3] (see @sec:distributions) are typically parameterized. Any instance of a distribution that has some of its parameters bound to names instead of concrete values, e.g. $m = d_(mu = a, sigma = 0.7, lambda = b, ...)$, constitutes a valid statistical model $m(theta)$ with model parameters $theta = (a, b)$.
+
+When probability distributions are combined via a Cartesian product (see @sec:product-distribution), then the named tuples that contain their free parameter values are concatenated. So $m = d_(mu = a, sigma = b) times d_(mu = c, sigma = 0.7)$ constitutes a model $m(theta)$ with model parameters $theta = (a, b, c)$.
+
+Distribution parameters may also be bound to the output of functions, and if those functions have inputs that are bound to names instead of values (or again bound to such functions, recursively), then those names become part of the model parameters. A configuration $m = d_(mu = a, sigma = 0.7, lambda = f)$, $f = "sum"(4.2, g)$, $g = "sum"(1.3, b)$, for example, also constitutes a (different) model $m(theta)$ with parameters $theta = (a, b, c)$.
+
+If all parameter values of a probability distribution are set to concrete values, so if there are not directly (or indirectly via functions) bound to names, we call this probability distribution a concrete distribution here. Such distributions can be used as Bayesian priors (see @sec:bayesian-inference).
+
+The variates of all distributions (so the possible results of random draws from them) are also named tuples in all cases. So even instances of univariate distributions, like the normal distributions, have variates like $(x = dots)$. The names in the variate tuples can be configured for each instance of a distribution, and must be unique across all distributions that are used together in a model. In Cartesian products of distributions, their variate tuples are concatenated. As with parameter tuples, nested tuples are not supported. The tuple entries, however, may be vector-valued, in contrast to parameter tuples.
+
+=== Probability density functions (PDFs) <sec:what-is-a-pdf>
+
+Statistics literature often discriminates between probability density functions (PDF) for continuous probability distributions and probability mass functions (PMF) for discrete probability distributions. This standard use the term PDF for both continuous and discrete distributions. The concept of density is to be understood in terms of densities in the realm of measure theory here, that is the density of a probability measure (distribution) is its Radon-Nikodym derivative in respect to an (implied) reference measure.
+
+The choice of reference measure would be arbitrary in principle, which scales likelihood functions (@sec:likelihood-definition) by a constant factor that depends on choice of reference. In this standard, a specific reference measures is implied for each probability distribution, typically the Lebesgue measure for continuous distributions and the counting measure for discrete distributions. The standard aims to to match the PDF (resp.~PMF) most commonly used in literature for each specific probability distribution and the mathematical form of the PDF is documented explicitly for each distribution in the standard. So within HS#super[3], probability densities and likelihood functions are unambiguous.
+
+Here we use $"PDF"(m(theta), x)$ to denote the density value of the probability distribution/measure $m$, parameterized by $theta$, at the point/variate $x$, in respect to the implied reference for $m$.
+
+=== Observed and simulated data <sec:data-generation>
+
+The term data refers here to any collection of values that represents the outcome of an experiment. Data takes the same form as variates of distributions (see @sec:distributions), i.e.~named tuple of real values or vectors. To compare given data with a given model, the names and shapes of the data entries must match the variates of the probability distributions $m(theta)$ that the model returns for a specific choice of parameters $theta$.
+
+This means that given a model $m$ and concrete parameter values $theta$, drawing a set of random values from the probability distribution $m(theta)$ produces a valid set of simulated observations. Implementations can use this to provide mock-data generation capabilities.
+
+=== Likelihood functions <sec:likelihood-definition>
+
+The concrete probability distribution $m(theta)$ that a model $m$ returns for specific parameter values $theta$ can be compared to observed data $x$. This gives rise to a likelihood $cal(L)_(m,x)(theta) = "PDF"(m(theta), x)$ that is a real-valued function on the parameter space. Multiple distributions/models that describe different modes of observation can be combined with multiple sets of data that cover those modes of observation into a single likelihood (@sec:likelihoods). In addition to using observed data, implementations may provide the option to use random data generated from the model (see @sec:data-generation) to check for Monte-Carlo closure.
+
+=== Frequentist parameter inference <sec:frequentist-inference>
+
+The standard method of frequentist inference is the maximum (or, respectively, profile) likelihood method. In the vast majority of cases, the test statistic used here is the likelihood ratio, that is, the ratio of two values of the likelihood corresponding to two different points in parameter space: one that maximizes the likelihood unconditionally, one one that maximizes the likelihood under some condition such as the values of the parameters of interest expected in the absence of a deviation from the null hypothesis. The corresponding building blocks for such an analysis, such as the list of parameters of interest and the likelihood function to be used, are specified in the analysis section of an HS#super[3] configuration (@sec:analyses).
+
+=== Bayesian parameter inference <sec:bayesian-inference>
+
+The standard also encompasses the specification of Baysian posterior distributions over parameters by combining (@sec:analyses) likelihoods with probabilty distributions that acts the priors. Here concrete distributions are used to describe the prior probability of parameters in addition to parameterized distributions that are used to describe of the probability of observing specific data.
+
+== How to read this document
+
+In the context of this document, any `JSON` object is referred to as a struct. A key-value-pair inside such a struct is referred to as a component. If not explicitly stated otherwise, all components mentioned are mandatory.
+
+The components located inside the top-level struct are referred to as top-level components.
+
+The keywords #sc[optional] and #sc[required], as well as #sc[should] and #sc[may] are used in accordance with IETF requirement levels @rfc2119.
+
+== Terms and Types
+
+This is a list of used types and terms in this document.
+
+- `struct`: represented with \{ \}, containing a _key:value_ mapping, keys are of type `string`.
+- `component`: key-value pair within a struct
+- `array`: array of items (either `string`s or `number`s) without keys. Represented with `[...]`.
+- `string`: references to objects, names and arbitrary information.
+- `number`: either floating or integer type values
+- `boolean`: boolean values; they can be encoded as `true` and `false`
+
+All `struct`s defining functions, distributions, parameters, variables, domains, likelihoods, data or parameter points will be referred to as `object`s. All `object`s #sc[must] always have a component `name` that #sc[must] be unique among all `object`s.
+
+Within most top-level `component`s, any one `string` given as a value to any component #sc[should] refer to the `name` of another `object`, unless explicitly stated otherwise. Top-level `component`s in which this is not the case are explicitly marked as such.
+
+== File format
+
+HS#super[3] documents are encoded in the JSON format as defined in ISO/IEC 21778:2017 @json. Implementations #sc[may] support other serialization formats that support a non-ambiguous mapping to JSON, such as TOML or YAML, in which case they #sc[should] use a different file extension.
+
+== Validators
+
+Future versions of this standard will recommend official validator implementations and schemata. Currently, these have not been finalized.
+
+== How to get in touch
+
+Visit the GitHub page #link("https://github.com/hep-statistics-serialization-standard/hep-statistics-serialization-standard").

--- a/docs/chapters/2.1.1_fundamental_distributions.typ
+++ b/docs/chapters/2.1.1_fundamental_distributions.typ
@@ -1,0 +1,244 @@
+#import "/docs/hs3-defs.typ": sc
+// Chapter 2.1.1: Fundamental Distributions
+
+=== Univariate fundamental distributions
+
+This section contains univariate fundamental distributions in the
+sense that they cannot refer to any other distribution -- only to
+functions, parameters and exactly one variable.
+
+==== Argus distribution
+
+The Argus background distribution is defined as
+
+$ "ArgusPdf"(m, m_0, c, p) = frac(1, cal(M)) dot m dot lr([1 - lr((frac(m, m_0)))^2])^p dot exp lr([c dot lr((1 - lr((frac(m, m_0)))^2))]) $
+
+and describes the ARGUS background shape.
+
+- `name`: custom unique string
+- `type`: `argus_dist`
+- `mass`: name of the variable $m$ used as mass
+- `resonance`: value or name of the parameter used as resonance $m_0$
+- `slope`: value or name of the parameter used as slope $c$
+- `power`: value or name of the parameter used as exponent $p$.
+
+==== Continued Poisson distribution
+
+The continued Poisson distribution of the variable $x$ is defined as
+
+$ "ContinuedPoissonPdf"(x, lambda) = frac(1, cal(M)) exp(x dot ln lambda - lambda - ln Gamma(x+1)), $
+
+where $Gamma$ denotes the Euler Gamma function.
+
+This function is similar the the Poisson distribution (see @dist:poisson), but can accept non-integer values for $x$. Notably, the differences between the two might be significant for small values of $x$ (below x). Nevertheless, the distribution is useful to deal with datasets with non-integer event counts, such as Asimov datasets @asymptotics.
+
+- `name`: custom unique string
+- `type`: `poisson_dist`
+- `x`: name of the variable $x$ (usually referred to as $k$ for the standard integer case)
+- `mean`: value or name of the parameter used as mean $lambda$.
+
+==== Uniform distribution
+
+The continuous uniform distribution is defined as:
+
+$ "UniformPdf"(x) = frac(1, cal(M)) $
+
+- `name`: custom unique string
+- `type`: `uniform_dist`
+- `x`: name of the variable $x$
+
+==== Crystal Ball distribution
+
+The generalized Asymmetrical Double-Sided Crystal Ball line shape,
+composed of a Gaussian distribution at the core, connected with two
+power-law distributions describing the lower and upper tails, given by
+
+$ "CrystalBallPdf"(m; m_0, sigma, alpha_L, n_L, alpha_R, n_R) = frac(1, cal(M)) cases(
+  A_L dot (B_L - frac(m - m_0, sigma_L))^(-n_L) &"for" frac(m - m_0, sigma_L) < -alpha_L,
+  exp(-frac(1, 2) dot [frac(m - m_0, sigma_L)]^2) &"for" frac(m - m_0, sigma_L) <= 0,
+  exp(-frac(1, 2) dot [frac(m - m_0, sigma_R)]^2) &"for" frac(m - m_0, sigma_R) <= alpha_R,
+  A_R dot (B_R + frac(m - m_0, sigma_R))^(-n_R) &"otherwise",
+) $
+
+where
+
+$ A_i &= (frac(n_i, |alpha_i|))^(n_i) dot exp(-frac(|alpha_i|^2, 2)) \
+  B_i &= frac(n_i, |alpha_i|) - |alpha_i| $
+
+The keys are
+
+- `name`: custom string
+- `type`: `crystalball_dist`
+- `m`: name of the variable $m$
+- `m0`: name or value of the central value $m_0$
+- `alpha`: value or names of $alpha_L$ and $alpha_R$ from above. #sc[must not] be used in conjunction with `alpha_L` or `alpha_R`.
+- `alpha_L`: value or names of $alpha_L$ from above. #sc[must not] be used in conjunction with `alpha`.
+- `alpha_R`: value or names of $alpha_R$ from above. #sc[must not] be used in conjunction with `alpha`.
+- `n`: value or names of $n_L$ and $n_R$ from above. #sc[must not] be used in conjunction with `n_L` or `n_R`.
+- `n_L`: value or names of $n_L$ from above. #sc[must not] be used in conjunction with `n`.
+- `n_R`: value or names of $n_R$ from above. #sc[must not] be used in conjunction with `n`.
+- `sigma`: value or names of $sigma_L$ and $sigma_R$ from above. #sc[must not] be used in conjunction with `sigma_L` or `sigma_R`.
+- `sigma_L`: value or names of $sigma_L$ from above. #sc[must not] be used in conjunction with `sigma`.
+- `sigma_R`: value or names of $sigma_R$ from above. #sc[must not] be used in conjunction with `sigma`.
+
+==== Exponential distribution
+
+The exponential distribution is defined as
+
+$ "ExponentialPdf"(x, c) = frac(1, cal(M)) dot exp(-c dot x) $
+
+- `name`: custom unique string
+- `type`: `exponential_dist`
+- `x`: name of the variable $x$
+- `c`: value or name of the parameter used as coefficient $c$.
+
+==== Gaussian/normal distribution
+
+The Gaussian/normal distribution is defined as
+
+$ "GaussianPdf"(x, mu, sigma) = frac(1, cal(M)) exp(-frac((x - mu)^2, 2 sigma^2)) $
+
+- `name`: custom unique string
+- `type`: `gaussian_dist` _or_ `normal_dist`
+- `x`: name of the variable $x$
+- `mean`: value or name of the parameter used as mean value $mu$
+- `sigma`: value or name of the parameter encoding the standard deviation $sigma$.
+
+==== Generalized Normal distribution
+
+The generalized normal distribution is defined as
+
+$ "GeneralizedNormalPdf"(x, mu, alpha, beta) = frac(1, cal(M)) exp{-(frac(|x - mu|, alpha))^beta} $
+
+cf. the #link("https://en.wikipedia.org/wiki/Generalized_normal_distribution")[Wikipedia definition].
+
+This form is of particular use with values of $beta tilde 8$ to generate a flat-topped distribution useful for "2 point" parameter-constraints between models where there is no clear preference but their average should not be particularly favoured. (In such usage, the template points should ideally be located at $|x| < plus.minus 1$, to avoid disfavouring a pure solution.)
+
+- `name`: custom unique string
+- `type`: `generalized_normal_dist`
+- `x`: name of the variable $x$
+- `mean`: value or name of the parameter used as mean value $mu$
+- `alpha`: value or name of the $alpha$ parameter encoding the width; this corresponds to $sigma = alpha \/ sqrt(2)$ when $beta = 2$.
+- `beta`: power $beta$ to which the exponent is raised, $beta = 2$ corresponding to the $"GaussianPdf"$ shape.
+
+==== Log-Normal distribution
+
+The log-normal distribution is defined as
+
+$ "LogNormalPdf"(x, mu, sigma) = frac(1, cal(M)) frac(1, x) exp(-frac((ln(x) - mu)^2, 2 sigma^2)) $
+
+- `name`: custom unique string
+- `type`: `lognormal_dist`
+- `x`: name of the variable $x$
+- `mu`: value or name of the parameter used as $mu$
+- `sigma`: value or name of the parameter $sigma$ describing the shape
+
+==== Poisson distribution <dist:poisson>
+
+The Poisson distribution of the variable $x$ is defined as
+
+$ "PoissonPdf"(x, lambda) = frac(1, cal(M)) frac(lambda^x, x!) e^(-lambda). $
+
+where $x$ is required to be an integer.
+In this case, the behavior for non-integer values of $x$ is undefined.
+
+- `name`: custom unique string
+- `type`: `poisson_dist`
+- `x`: name of the variable $x$ (usually referred to as $k$ for the standard integer case)
+- `mean`: value or name of the parameter used as mean $lambda$.
+
+==== Polynomial distribution
+
+The polynomial distribution is defined as
+
+$ "PolynomialPdf"(x, a_0, a_1, a_2, ...) = frac(1, cal(M)) sum_(i=0)^n a_i x^i = a_0 + a_1 x + a_2 x^2 + ... $
+
+- `name`: custom unique string
+- `type`: `polynomial_dist`
+- `x`: name of the variable $x$
+- `coefficients`: array of coefficients $a_i$. The length of this array implies the degree of the polynomial.
+
+=== Multivariate fundamental distributions
+
+This section contains multivariate fundamental distributions. They may
+refer to functions, parameters and more than one variable.
+
+==== Barlow-Beeston-Lite Constraint distribution
+
+This distribution represents a product of Poisson distributions
+defining the statistical uncertainties of the histogram templates
+defined in a `histfactory_func`.
+
+$ "BarlowBeestonLitePoissonConstraintPdf"(x) = frac(1, cal(M)) product_(i)^n "PoissonPdf"(x_i dot tau_i, tau_i) $
+
+- `name`: custom unique string
+- `type`: `barlow_beeston_lite_poisson_constraint_dist`
+- `x`: array of names of the variables $x_i$. This also includes mixed arrays of values and names.
+- `expected`: array of central values $tau_i$
+
+==== Multivariate normal distribution
+
+The multivariate normal distribution is defined as
+
+$ "MvNormalPdf"(bold(x), bold(mu), bold(Sigma)) = frac(1, cal(M)) exp(-frac(1, 2) (bold(x) - bold(mu))^top bold(Sigma)^(-1) (bold(x) - bold(mu))), $
+
+with $bold(Sigma) in bb(R)^(k times k)$ being positive-definite.
+
+- `name`: custom unique string
+- `type`: `multivariate_normal_dist`
+- `x`: array of names of the variables $bold(x)$. This also includes mixed arrays of values and names.
+- `mean`: array of length $k$ of values or names of the parameters used as mean values $bold(mu)$
+- `covariances`: an array comprised of $k$ sub-arrays, each of which is also of length $k$, designed to store values or names of the entries of the covariance matrix $bold(Sigma)$. In general, the covariance matrix $bold(Sigma)$ #sc[must] be symmetric and positive semi-definite.
+
+==== Generic distribution
+
+_Note: Users should prefer the specific distributions defined in this standard over generic distributions where possible, as implementations of these will typically be more optimized. Generic distributions should only be used if no equivalent specific distribution is defined._
+
+A generic distribution is defined by an expression that represents the PDF of the distribution in respect to the Lebesgue measure. The expression must be a valid HS#super[3]-expression string (see @sec:generic_expression).
+
+- `name`: custom string
+- `type`: `generic_dist`
+- `expression`: a string with a generic mathematical expression. Simple mathematical syntax common to most programming languages should be used here, such as `x-2*y+z`. The arguments `x`, `y` and `z` in this example #sc[must] be parameters, functions or variables.
+
+The distribution is normalized by the implementation, so a normalization term #sc[should not] be included in the expression. If the expression results in a negative value, the behavior is undefined.
+
+==== HistFactory distribution
+
+#include "/docs/parts/histfactory.typ"
+
+==== Relativistic Breit-Wigner distribution
+
+The relativistic Breit-Wigner distribution describes the line-shape of a resonance in the mass spectrum of a two-particle system. It is assumed that the resonance can decay into a list of channels.
+
+The first channel in the list indicates the system for which mass
+distribution is modelled.
+
+$ "BreitWignerPDF"(m, m_"BW") &= frac(1, cal(M)) frac(m Gamma_1(m), |m_"BW"^2 - m^2 - i m_"BW" Gamma(m)|^2), \
+  Gamma(m) &= sum_i Gamma_i (m), $ <eq:relativistic_breit_wigner_dist>
+
+When modelling the mass spectrum, the term $m$ in the numerator of @eq:relativistic_breit_wigner_dist accounts for a jacobian of transformation from $m^2$ to $m$. The width term $Gamma_1(m)$ adds for the phase space factor for the channel of interest
+
+- `name`: custom unique string
+- `type`: `relativistic_breit_wigner_dist`
+- `mass`: name of the mass variable $m_"BW"$
+- `channels`: list of `structs` encoding the channels
+
+Each of the channels is defined by the partial width $Gamma_i (m)$, given as
+
+$ Gamma_i (m) &= Gamma_("BW",i) n_(l i)^2 (m) rho_i (m), \
+  rho_i (m) &= 2 q_i (m) \/ m, \
+  q_i (m) &= sqrt((m^2 - (m_(1 i) + m_(2 i))^2)(m^2 - (m_(1 i) - m_(2 i))^2)) \/ (2m), \
+  n_(l i)(m) &= z_i^(l i)(m) h_(l i)(z_i (m)), \
+  z_i (m) &= q_i (m) R_i $
+
+The $h_l (z)$ is the standard Blatt-Weisskopf form-factors, $h_0^2(z) = 1\/(1+z^2)$, $h_1^2(z) = 1\/(9+3z^2+z^4)$, and so on (Eqs.(50.30-50.35) in Ref.~@pdg2023). The `struct`s defining the channels should contain the following keys:
+
+- `name`: name of the final state (#sc[optional])
+- `Gamma`: partial width $Gamma_"BW"$ of the resonance
+- `m1`: mass $m_1$ of the first particle the resonance decays into (default value $0$)
+- `m2`: mass $m_2$ of the second particle the resonance decays into (default value $0$)
+- `l`: orbital angular momentum $l$ (default value $0$)
+- `R`: form-factor size parameter $R$ (default value $3$ GeV)
+
+For non-zero angular momentum, $Gamma_i (m_"BW")$ gives an approximation to the partial width of the resonance, not $Gamma_("BW",i)$.
+A commonly used approximation of the relativistic Breit-Wigner function with the constant width is a special case of @eq:relativistic_breit_wigner_dist, where the `[channels]` argument contains a single channel with $m_1 = 0$, $m_2 = 0$, and $l = 0$.

--- a/docs/chapters/2.1.2_composite_distributions.typ
+++ b/docs/chapters/2.1.2_composite_distributions.typ
@@ -1,0 +1,123 @@
+#import "/docs/hs3-defs.typ": sc
+// Chapter 2.1.2: Composite Distributions
+
+=== Composite distributions
+
+This section contains composite distributions in the sense that they refer to other distribution which they combine or modify in some way.
+
+==== Mixture distribution
+
+The mixture distribution, sometimes called addition of distributions, is a (weighted) sum of distributions $f_i (arrow(x))$, depending on the same variable(s) $arrow(x)$:
+
+$ "MixturePdf"(x) = frac(1, cal(M)) sum_(i=1)^n c_i dot f_i (arrow(x)), $
+
+where the $c_i$ are coefficients and $arrow(x)$ is the vector of variables.
+
+- `name`: custom unique string
+- `type`: `mixture_dist`
+- `name`: name of the variable $x$ (#sc[optional], since the variable is fully defined by the summands)
+- `summands`: array of names referencing distributions
+- `coefficients`: array of names of coefficients $c_i$ or numbers to be added
+- `extended`: boolean denoting whether this is an extended distribution (#sc[optional], as it can be inferred from the lengths of the lists for `summands` and `coefficients`)
+
+This distribution can be treated as extended or as non-extended.
+
+- If the number of coefficients equals the number of distributions and `extended` is `false`, then the sum of the coefficient must be (approximately) one.
+- If the number of coefficients equals the number of distributions and `extended` is `true`, then the sum of the coefficients will be used as the Poisson rate parameter and the mixture distribution itself will use the coefficients normalized by their sum.
+- If the number of coefficients is one less than the number of distributions, then `extended` must be `false` and $c_n$ is computed from the other coefficients as
+
+$ c_n = 1 - sum_(i=1)^(n-1) c_i . $
+
+==== Product distribution <sec:product-distribution>
+
+The product of independent distributions $f_i$ is defined as
+
+$ "ProductPdf"(x) = frac(1, cal(M)) product_i^n f(x). $
+
+- `name`: custom string
+- `type`: `product_dist`
+- `x`: name of the variable $x$ (#sc[optional], since the variable is fully defined by the factors)
+- `factors`: array of names referencing distributions
+
+==== Density Function distribution
+
+A distribution that is specified via a non-normalized density function $f(x)$. Formally, it corresponds to the probability measure that has the density $f(x)$ in respect to the Lebesgue measure.
+
+The density function is normalized automatically by $cal(M) = integral f(x) d x$, so the PDF of the distribution is
+
+$ "DensityFunctionPdf"(f, x) = frac(f(x), cal(M)) $
+
+The distribution can be specified either via the non-normalized density function $f(x)$ or via the non-normalized log-density function $log(f(x))$:
+
+- `density_function_dist`: Specified via the PDF $f(x)$
+  - `name`: custom string
+  - `type`: `density_function_dist`
+  - `function`: The density function $f$
+- `log_density_function_dist`: Specified via the log-PDF $log(f(x))$
+  - `name`: custom string
+  - `type`: `log_density_function_dist`
+  - `function`: The density function $f$
+
+==== Poisson point process <dist:poisson-point-process>
+
+A Poisson point process distribution is understood here as the distribution of the outcomes of a (typically inhomogeneous) Poisson point process. In particle physics, such a distribution is often called an extended distribution @barlow-extended-ml.
+
+In HS#super[3], a Poisson point process distribution is specified using a global-rate parameter $lambda$ and an underlying distribution $m$, either explicitly or implicitly (see below).
+
+Random values are drawn from the Poisson point process distribution by drawing a random number $n$ from a Poisson distribution of the global-rate $lambda$, and then drawing $n$ random values from the underlying distribution $m$. The resulting random values are vectors $x$ of length $n$, so their length varies.
+
+The PDF the Poisson point process distribution at an outcome $x$ (a vector of length $n$) is
+
+$ "PoissonPointProcessPdf"(lambda, m, x) = "PoissonPdf"(n, lambda) dot product_i^n "PDF"(m, x_i). $
+
+In particle physics, the function $"PoissonPointProcessPdf"(lambda, m(theta), x)$, for a fixed observation $x$ and varying parameters $lambda$ and $theta$, is often called an extended likelihood.
+
+A Poisson point process distribution can be specified in HS#super[3] in two ways:
+
+- `rate_extended_dist`: The global-rate parameter $lambda$ and underlying distribution $m$ are specified explicitly:
+  - `name`: custom string
+  - `type`: `rate_extended_dist`
+  - `rate`: The global rate $lambda$
+  - `dist`: The underlying distribution $m$
+
+  The name of the variable $x$ is taken from the underlying distribution. The underlying distribution #sc[must] not be referred to from other components of the statistical model.
+
+- `rate_density_dist`: Specified via a non-normalized rate-density function $f$. Both the global-rate parameter and the underlying distribution are implicit: $lambda = integral f(y) d y$ and $m = "DensityFunctionPdf"(f)$. More formally, the distribution corresponds to the inhomogeneous Poisson point process that is defined by a non-normalized rate measure which has density $f$ in respect to the Lebesque measure.
+  - `name`: custom string
+  - `type`: `rate_density_dist`
+  - `x`: name of the variable $x$
+  - `density`: The rate-density function $f$
+
+==== Bin-count distribution <dist:bin-counts>
+
+This is a binned version of the Poisson point process distribution (@dist:poisson-point-process). It is the distribution of the bin counts that result from histogramming the outcomes of a Poisson point process distribution using a given binning scheme (see @sec:binned-data).
+
+Like the Poisson point process distribution, a Bin-counts distribution can either be specified via a global-rate parameter $lambda$ and an underlying distribution $m$, or via a rate-density function $f$ (in which case $lambda$ and $m$ are implicit). In addition, the binning scheme also has to be specified in either case, unless it can be inferred (see below).
+
+For $k$ bins, this type of distribution corresponds to a product of $k$ Poisson distributions with rates
+
+$ nu_i &= lambda dot integral_("bin"_i) "PDF"(y, m) d y quad "equivalent to" \
+  nu_i &= integral_("bin"_i) f(y) d y $
+
+The PDF of the bin-counts distribution at an outcome $x$ (a vector of length $k$, same as the number of bins) is
+
+$ "BinCountsPdf"(x) = product_i^k "PoissonPdf"(x_i, nu_i) $
+
+- `bincounts_extended_dist`: The global-rate parameter $lambda$ and underlying distribution $m$ are specified explicitly:
+  - `name`: custom string
+  - `type`: `bincounts_extended_dist`
+  - `rate`: The global rate $lambda$
+  - `dist`: The underlying distribution $m$
+  - `axes`: a definition of the binning to be used, following the definitions in @sec:binned-data. #sc[optional] if `dist` is a binned distribution, in which case the same binning is used by default.
+
+  The name of the variable $x$ is taken from the underlying distribution. The underlying distribution #sc[must] not be referred to from other components of the statistical model.
+
+- `bincounts_density_dist`: Specified via a non-normalized rate-density function $f$. Both the global-rate parameter and the underlying distribution are implicit: $lambda = integral f(y) d y$ and $m = "DensityFunctionPdf"(f)$.
+
+  More formally, the distribution corresponds to the inhomogeneous Poisson point process that is defined by a non-normalized rate measure which has density $f$ in respect to the Lebesque measure.
+
+  - `name`: custom string
+  - `type`: `bincounts_density_dist`
+  - `x`: name of the variable $x$
+  - `density`: The rate-density function $f$
+  - `axes`: a definition of the binning to be used, following the definitions in @sec:binned-data.

--- a/docs/chapters/2.1_distributions.typ
+++ b/docs/chapters/2.1_distributions.typ
@@ -1,0 +1,37 @@
+#import "/docs/hs3-defs.typ": sc
+// Chapter 2.1: Distributions
+
+== Distributions <sec:distributions>
+
+The top-level component `distributions` contains an array of distributions in struct format. Distributions #sc[must] be normalized, thus, the letter $cal(M)$ in the following descriptions will always relate to the normalization of the distribution. The value of $cal(M)$ is conditional on the current domain. It #sc[must] be chosen such that the integral of the distribution over the current domain equals one. The implementations might chose to perform this integral using analytical or numerical means.
+
+Each distribution #sc[must] have the components `type`, denoting the kind of distribution described, and a component `name`, which acts as a unique identifier of this distribution among all other named objects. Distributions in general have the following keys:
+
+- `name`: custom unique string (#sc[required]), e.g.~`my_distribution_of_x`
+- `type`: string (#sc[required]) that determines the kind of distribution, e.g.~`gaussian_dist`
+- `...`: each distribution #sc[may] have components for the various individual parameters. For example, distributions of type `gaussian_dist` have the specific components `mean`, `sigma` and `x`. In general, these components #sc[may] be strings as references to other `objects`, but #sc[may] also directly yield numeric or boolean values. Depending on the parameter and the type of distribution, they appear either in single item or array format.
+
+#figure(caption: [Example: Distributions])[
+```json
+"distributions":[
+  {
+    "name":"gauss1",
+    "type":"gaussian_dist",
+    "mean":1.0,
+    "sigma":"param_sigma",
+    "x":"param_x"
+  },
+  {
+    "name":"exp1",
+    "type":"exponential_dist",
+    "c":-2,
+    "x":"data_x"
+  },
+  ...
+]
+```
+]
+
+Distributions can be treated either as `extended` or as non-`extended` @barlow-extended-ml. Some distributions are always extended, others can never be extended, yet others can be used in extended and non-extended scenarios and have a switch selecting between the two. An non-extended distribution is always normalized to the unity. An extended distribution, on the other hand, can yield values larger than unity, where the yield is interpreted as the number of predicted events. That is to say, the distribution is augmented by a factor that is a Poisson constraint term for the total number of events.
+
+In the following, all distributions supported in HS#super[3] v0.2.9 are listed in detail. Future versions will expand upon this list.

--- a/docs/chapters/2.2_functions.typ
+++ b/docs/chapters/2.2_functions.typ
@@ -1,0 +1,55 @@
+#import "/docs/hs3-defs.typ": sc
+// Chapter 2.2: Functions
+
+== Functions <sec:functions>
+
+The top-level component `functions` describes an array of mathematical functions in struct format to be used as helper objects. Similar to distributions each entry is #sc[required] to have the components `type` and `name`. Other components are dependent on the kind of functions. The field `name` is #sc[required] and may be any custom unique string. Functions in general have the following components:
+
+- `name`: custom unique string
+- `type`: string that determines the kind of function, e.g. `sum`
+- `...`: each function has individual parameter keys for the various individual parameters. For example, functions of type `sum` have the parameter key `summands`. In general, these keys can describe strings as references to other objects or numbers. Depending on the parameter and the type of function, they appear either in single item or array format.
+
+#figure(caption: [Example: Functions])[
+```json
+"functions": [
+  {
+    "name" : "sum1",
+    "type" : "sum",
+    "summands" : [1.8, 4, "param_xy"]
+  },
+  ...
+]
+```
+]
+
+In the following the implemented functions are described in detail.
+
+=== Product
+
+A product of values or functions $a_i$.
+
+$ "Prod" = product_i^n a_i $
+
+- `name`: custom unique string
+- `type`: `product`
+- `factors`: array of names of the elements of the product or numbers.
+
+=== Sum
+
+A sum of values or functions $a_i$.
+
+$ "Sum" = sum_i^n a_i $
+
+- `name`: custom unique string
+- `type`: `sum`
+- `summands`: array of names of the elements of the sum or numbers.
+
+=== Generic Function
+
+_Note: Users should prefer the specific functions defined in this standard over generic functions where possible, as implementations of these will typically be more optimized. Generic functions should only be used if no equivalent specific distribution is defined._
+
+A generic function is defined by an expression. The expression must be a valid HS#super[3]-expression string (see @sec:generic_expression).
+
+- `name`: custom unique string
+- `type`: `generic_function`
+- `expression`: a string with a generic mathematical expression. Simple mathematical syntax common to programming languages should be used here, such as `x-2*y+z`. For any non-elementary operations, the behavior is undefined.

--- a/docs/chapters/2.3_data.typ
+++ b/docs/chapters/2.3_data.typ
@@ -1,0 +1,134 @@
+#import "/docs/hs3-defs.typ": sc
+// Chapter 2.3: Data
+
+== Data <sec:data>
+
+The top-level component `data` contains an array of data sets in struct format. Each data set needs to contain the components `type` and `name`. Other components are dependent on the type of data set as demonstrated below:
+
+- `name`: custom string
+- `type`: string that determines the format of the observations
+- `...`: each type of observations has different parameter keys. Some of these are #sc[optional] and marked accordingly in the more detailed description below
+
+A detailed description of the different types with examples can be found below.
+
+While data, in most settings, has no uncertainty attached to it, this standard _does_ allow to provide data with uncertainty, as there are some settings in which uncorrelated or correlated errors need to be taken into account. These include cases such as
+
+- generated data obtained from importance sampling, including a (potentially Gaussian) uncertainty from the frequency weights
+- unfolded data, resulting from arbitrarily complex transformation functions involving statistical models folding some degree of uncertainty into the data points themselves
+
+While it should always be preferred to publish "raw" data, allowing to include pre-processed data with corresponding uncertainties expands the possible applications considerably.
+
+=== Point Data
+
+Point data describes a measurement of a single number, with a possible uncertainty (error).
+
+- `name`: custom string
+- `type`: `point`
+- `value`: value of this data point
+- `uncertainty`: (#sc[optional]) uncertainty of this data point
+
+#figure(caption: [Example: Point Data])[
+```json
+"data":[
+  {
+    "name":"data1",
+    "type":"point",
+    "value":0.,
+    "uncertainty":1.
+  }
+]
+```
+]
+
+=== Unbinned Data
+
+Unbinned data describes a measurement of multiple data points in a possibly multi-dimensional space of variables. These data points can be weighted.
+
+- `name`: custom string
+- `type`: `unbinned`
+- `entries`: array of arrays containing the coordinates/entries of the data
+- `axes`: array of structs representing the axes. Each struct #sc[must] have the components `name` as well as `max` and `min`.
+- `weights`: (#sc[optional]) array of values containing the weights of the individual data points, to be used for $chi^2$ comparisons and fits. If this component is not given, weight 1 is assumed for all data points. If given, the array needs to be of the same length as `entries`.
+- `entries_uncertainties`: (#sc[optional]) array of arrays containing the errors/uncertainties of each entry. If given, the array needs to be of the same shape as `entries`.
+
+#figure(caption: [Example: Unbinned Data])[
+```json
+"data":[
+  {
+    "name":"data1",
+    "type":"unbinned",
+    "weights":[ 9.0, 18.4 ],
+    "entries":[ [1,3], [2,9] ],
+    "entries_uncertainties":[ [0.3], [0.6] ],
+    "axes":[
+      { "name":"variable1", "min":1, "max":3 },
+      { "name":"variable2", "min":-10, "max":10 },
+      ...
+    ]
+  },
+  ...
+]
+```
+]
+
+=== Binned Data <sec:binned-data>
+
+Binned data describes a histogram of data points with bin contents in a possibly multi-dimensional space of variables. Whether entries that fall precisely on the bin boundaries are sorted into the smaller or larger bin is under the discretion of the creator of the model and thus not defined.
+
+- `name`: custom string
+- `type`: `binned`
+- `contents`: array of values representing the contents of the binned data set
+- `axes`: array of structs representing the axes. Each struct #sc[must] have the component `name`. Further, it must specify the binning through one of these two options:
+  + regular binnings are specified through the components `max`, `min` and `nbins`
+  + potentially irregular binnings are specified through the component `edges`, which contains an array of length $n+1$, where the first and last entries denote the minimum and and maximum of the variable, and all entries between denote the intermediate bin boundaries.
+- `uncertainty`: (#sc[optional]) struct representing the uncertainty of the contents. It consists of up to three components:
+  - `type`: denoting the kind of uncertainty, for now only Gaussian distributed uncertainties denoted as `gaussian_uncertainty` are supported
+  - `sigma`: array of the standard deviation of the entries in `contents`. Needs to be of the same length as `contents`
+  - `correlation`: (#sc[optional]) array of arrays denoting the correlation between the contents in matrix format. Must be of dimension length of `contents` $times$ length of `contents`. It can also be set to 0 to indicate no correlation.
+
+#figure(caption: [Example: Binned Data])[
+```json
+"data":[
+  {
+    "name":"data2",
+    "type":"binned",
+    "contents":[ 9.0, 18.4 ],
+    "axes":[ { "name":"variable1", "nbins":2, "min":1, "max":3 } ]
+  },
+  {
+    "name":"asimov_data2",
+    "type":"binned",
+    "contents":[ 9.0, 18.4, 13, 0. ],
+    "axes":[
+      { "name":"variable1", "nbins":2, "min":1, "max":3 },
+      { "name":"variable2", "edges":[0,10,100] }
+    ]
+  },
+  ...
+]
+```
+]
+
+This type can also be used to store pre-processed data utilizing the `uncertainty` component
+
+#figure(caption: [Example: Pre-processed binned Data])[
+```json
+"data":[
+  {
+    "name":"data4",
+    "type":"binned",
+    "contents":[ 9.0, 18.4 ],
+    "uncertainty" : {
+      "type": "gaussian_uncertainty",
+      "correlation" : 0,
+      "sigma" : [ 3, 4 ]
+    },
+    "axes":[
+      { "name":"variable1", "nbins":2, "min":1, "max":3 },
+      ...
+    ]
+  },
+  ...
+]
+```
+]

--- a/docs/chapters/2.4_likelihoods.typ
+++ b/docs/chapters/2.4_likelihoods.typ
@@ -1,0 +1,41 @@
+#import "/docs/hs3-defs.typ": sc
+// Chapter 2.4: Likelihoods
+
+== Likelihoods <sec:likelihoods>
+
+The top-level component `likelihoods` contains an array of likelihoods in struct format specifying mappings of distributions and observations. The corresponding distributions and observations are inserted as keys in string format referencing to distributions and observations defined in the respective top-level components, or as numbers for fixed data values.
+
+The combination of parameterized distributions $m_i (theta_i)$ with observations $x_i$ generates a likelihood function
+
+$ cal(L)(theta_1, theta_2, dots) = product_i "PDF"(m_i (theta_i), x_i) $
+
+The components of a likelihood struct are:
+
+- `name`: custom string
+- `distributions`: array of strings referencing the considered distributions
+- `data`: array of strings referencing the used data, must be of the same length as the array of `distributions`. Alternatively, the data-values for single-dimensional distributions can be given in-line. For example, this can be used for constraint terms representing auxiliary measurements.
+- `aux_distributions`: (#sc[optional]) array of strings referencing the considered auxiliary distributions defined in the top-level component `distributions`. They can be used to encode regularizers or penalty terms to aid the minimization. These observed data for these distributions is implicit and not part of `data`.
+
+#figure(caption: [Example: Likelihoods])[
+```json
+"likelihoods":[
+  {
+    "name":"likelihood1",
+    "distributions":[
+      "dist1",
+      "dist2",
+      "single_dimensional_dist_1",
+      ...
+    ],
+    "data":[
+      "data1",
+      "data2",
+      0,
+      ...
+    ],
+    "aux_distributions" : [ "regularization_term" ]
+  },
+  ...
+]
+```
+]

--- a/docs/chapters/2.5_domains.typ
+++ b/docs/chapters/2.5_domains.typ
@@ -1,0 +1,32 @@
+// Chapter 2.5: Domains
+
+== Domains <sec:domains>
+
+The top-level component `domains` contains an array of domains giving information on the ranges of parameters and variables in struct format. Within a specified domain, the corresponding model is expected to yield valid values. Each domain must contain a `name` and a `type` although right now only the `product_domain` type is supported, even though others like e.g.~a simplex domain might be added later. A domain consists of the following components:
+
+- `name`: custom string
+- `type`: `product_domain`
+- `axes`: array of parameters and variables in this domain (see below)
+
+The component `axes` itself is an array of ranges each containing the components `min`, `max` and `name`.
+
+- `name`: custom string
+- `max`: upper bound of range
+- `min`: lower bound of range
+
+#figure(caption: [Example: Domains])[
+```json
+"domains":[
+  {
+    "name":"domain1",
+    "type":"product_domain",
+    "axes": [
+      { "name" : "par_1", "max" : 1, "min" : 8 },
+      { "name" : "par_2", "max" : 4.78, "min" : 6 },
+      ...
+    ]
+  },
+  ...
+]
+```
+]

--- a/docs/chapters/2.6_parameter_points.typ
+++ b/docs/chapters/2.6_parameter_points.typ
@@ -1,0 +1,31 @@
+#import "/docs/hs3-defs.typ": sc
+// Chapter 2.6: Parameter Points
+
+== Parameter points <sec:parameterpoints>
+
+The top-level component `parameter_points` contains an array of parameter configurations. These can be starting values for minimizations, parameter settings used to generate toy data, best-fit-values obtained, or points in parameter space used for different purposes.
+
+- `name`: custom string
+- `parameters`: array of parameter structs (see below)
+
+The component `parameters` is an array of components each containing:
+
+- `name`: custom string
+- `value`: number, value of variable
+- `const`: (#sc[optional]) boolean, whether variable is constant or not. Default is `false`.
+
+#figure(caption: [Example: Parameter points])[
+```json
+"parameter_points":[
+  {
+    "name" : "starting_values",
+    "parameters": [
+      { "name" : "par_1", "value": 3 },
+      { "name" : "par_2", "value": 7, "const": true },
+      ...
+    ]
+  },
+  ...
+]
+```
+]

--- a/docs/chapters/2.7_analyses.typ
+++ b/docs/chapters/2.7_analyses.typ
@@ -1,0 +1,32 @@
+#import "/docs/hs3-defs.typ": sc
+// Chapter 2.7: Analyses
+
+== Analyses <sec:analyses>
+
+The top-level component `analyses` contains an array of possible (automated) analyses. To that extent, likelihoods, parameters of interest and the affiliated domains are listed. Description of the components:
+
+- `name`: long custom string
+- `likelihood`: name as reference to a likelihood defined in the top-level component `likelihoods`
+- `parameter_of_interest`: (#sc[optional]) array of names as reference to parameters that are interesting for the analysis at hand
+- `domain`: name of a domain to be used for the parameters, defined in the top-level component `domains`
+- `init`: (#sc[optional]) name of an initial value to be used, defined in the top-level component `parameter_points`
+- `prior`: (#sc[optional]) name of a prior distribution, defined in the top-level component `distributions`. This is only used for Bayesian interpretations and should not be confused with auxiliary distributions listed in the likelihood section. The prior could, for example, be a product distribution of all the individual priors. If for any parameter, both a prior and a parameter domain are given, the prior should be truncated to the given parameter domain. Otherwise, implicit flat priors over the given parameter domain are assumed.
+
+All parameters of all distributions in the likelihood must either be listed under the domain referenced, or set to `const` in the parameter point referenced.
+
+#figure(caption: [Example: Analyses])[
+```json
+"analyses": [
+  {
+    "name" : "analysis1",
+    "likelihood" : "likelihood1",
+    "aux_likelihood_terms" : ["distribtion_1", "distribution_2", ...],
+    "parameters_of_interest" : ["param1"],
+    "domain" : "domain1" ,
+    "init" : "starting_values",
+    "prior" : "prior_dist"
+  },
+  ...
+]
+```
+]

--- a/docs/chapters/2.8_metadata.typ
+++ b/docs/chapters/2.8_metadata.typ
@@ -1,0 +1,23 @@
+#import "/docs/hs3-defs.typ": sc
+// Chapter 2.8: Metadata
+
+== Metadata <sec:metadata>
+
+The top-level component `metadata` contains meta-information related to the creation of the file. The component `hs3_version` stores the HS#super[3] version and is #sc[required] for now. Overview of the components:
+
+- `hs3_version`: (#sc[required]) HS#super[3] version number as String for reference
+- `packages`: (#sc[optional]) array of structs defining packages and their version number used in the creation of this file, depicted with the components `name` and `version` respectively
+- `authors`: (#sc[optional]) array of authors, either individual persons, or collaborations
+- `publications`: (#sc[optional]) array of document identifiers of publications associated with this file
+- `description`: (#sc[optional]) short abstract/description for this file
+
+#figure(caption: [Example: Metadata])[
+```json
+"metadata" : {
+  "hs3_version" : "0.2.0",
+  "packages" : [ { "name": "ROOT", "version": "6.28.02" } ],
+  "authors": ["The ATLAS Collaboration", "The CMS Collaboration"],
+  "publications": ["doiABCDEFG"]
+}
+```
+]

--- a/docs/chapters/2.9_misc.typ
+++ b/docs/chapters/2.9_misc.typ
@@ -1,0 +1,23 @@
+// Chapter 2.9: Miscellaneous
+
+== Miscellaneous <sec:misc>
+
+The top-level component `misc` can contain arbitrary, user-created information in struct format.
+
+#figure(caption: [Example: Miscellaneous])[
+```json
+"misc" : {
+  "customkey1" : "custom information 1" ,
+  "myPackage_internal" : {
+    "somekey" : "custom info only affecting myPackage",
+    "default_color_for_all_curves" : "fuchsia" }
+  }
+```
+]
+
+This top-level component is intended to store any and all additional information, including user- or backend-specific meta-information. Examples include, but are not limited to:
+
+- colors and styles for drawing distributions in this file
+- suggested settings for samplers or minimizers when working with the distributions in this file
+- comments explaining design choices made when building the model in this file
+- suggested names and paths for output files to be used by backends working with this file

--- a/docs/chapters/2_toplevels.typ
+++ b/docs/chapters/2_toplevels.typ
@@ -1,0 +1,18 @@
+#import "/docs/hs3-defs.typ": sc
+// Chapter 2: Top-level components
+
+= Top-level components <sec:toplevel>
+
+In the following, the top-level `component`s of HS#super[3] and their parameters/arguments are described. Each component is completely #sc[optional], but certain components #sc[may] depend on other components, which #sc[should] be provided in that case. The only exception is the component `metadata` containing the version of HS#super[3], which is always #sc[required]. The supported top-level components are
+
+- `distributions` (@sec:distributions): (#sc[optional]) array of `object`s defining distributions
+- `functions` (@sec:functions): (#sc[optional]) array of `object`s defining mathematical functions
+- `data` (@sec:data): (#sc[optional]) array of `objects` defining observed or simulated data
+- `likelihoods` (@sec:likelihoods): (#sc[optional]) array of `object`s defining combinations of distributions and data
+- `domains` (@sec:domains): (#sc[optional]) array of `object`s defining domains, describing ranges of parameters
+- `parameter_points` (@sec:parameterpoints): (#sc[optional]) array of `object`s defining parameter points. These #sc[may] be used as starting points for minimizations or to document best-fit-values or nominal truth values of datasets
+- `analyses` (@sec:analyses): (#sc[optional]) array of `object`s defining suggested analyses to be run on the models in this file
+- `metadata` (@sec:metadata): #sc[required] struct containing meta information; HS#super[3] version number (#sc[required]), authors, paper references, package versions, data/analysis descriptions (#sc[optional])
+- `misc` (@sec:misc): (#sc[optional]) struct containing miscellaneous information, e.g. optimizer settings, plotting colors, etc.
+
+In the following each of these are described in more detail with respect to their own structure.

--- a/docs/chapters/3.1_generic_expressions.typ
+++ b/docs/chapters/3.1_generic_expressions.typ
@@ -1,0 +1,40 @@
+#import "/docs/hs3-defs.typ": sc
+// Chapter 3.1: Generic Expressions
+
+== Generic Expressions <sec:generic_expression>
+
+This section details the HS#super[3] _generic expression_ language.
+Expressions can be use to specify generic functions and generic distributions.
+The implementations that support generic expression #sc[must] support:
+
+- Literal integer (format `1234`), boolean (format `TRUE` and `FALSE`) and floating point (format `123.4`, `1.234e2` and `1.234E2`) values.
+- Literal values for $pi$ (`PI`) and Euler's number (`EULER`).
+- The arithmetic operators addition (`x + y`), subtraction (`x - y`), multiplication (`x * y`), division (`x / y`) and exponentiation (`x^y`).
+- The comparison operators approximately-equal (`x == y`), exactly-equal (`x === y`), not-approximately-equal (`x != y`), not-exactly-equal (`x !== y`), less-than (`x < y`), less-or-equal (`x <= y`), greater-than (`x > y`) and greater-or-equal (`x >= y`).
+- The logical operators logical-inverse (`!a`), logical-and (`a && b`), logical-or (`a || b`).
+- Round brackets to specify the order of operations.
+- The ternary operator `condition ? result_if_true : result_if_false`
+- The functions
+  - `exp(x)`: Euler's number raised to the power of `x`
+  - `log(x)`: Natural logarithm of `x`
+  - `sqrt(x)`: The square root of `x`
+  - `abs(x)`: The absolute value of `x`
+  - `pow(x, y)`: `x` raised to the power of `y`
+  - `min(x, y)`: minimum of `x` and `y`
+  - `max(x, y)`: maximum of `x` and `y`
+  - `sin(x)`: The sine of `x`
+  - `cos(x)`: The cosine of `x`
+  - `tan(x)`: The tangent of `x`
+  - `asin(x)`: The inverse sin of `x`
+  - `acos(x)`: The inverse cosine of `x`
+  - `atan(x)`: The inverse tangent of `x`
+
+Symbols not defined here refer to variables in the HS#super[3] model.
+The operator precedence and associativity is according to the common conventions.
+Spaces between operators and operands are optional. There must be no space between a function name and the function arguments, spaces between function arguments are optional (`f(a, b)` and `f(a,b)` are correct but `f (a, b)` is not allowed).
+
+Division #sc[must] be treated as floating-point division (i.e. `2/3` should be equivalent to `2.0/3.0`).
+
+The approximately-equal (`a == b`) and the not-approximately-equal operator (`a != b`), #sc[should] compare floating-point numbers to within a small multiple of the unit of least precision.
+
+The behavior of any functions and operators not listed above is not defined, they are reserved for future versions of this standard. Implementations #sc[may] support additional functions and operators as experimental features, but their use is considered non-standard and results in non-portable and potentially non-forward-compatible HS#super[3] documents.

--- a/docs/chapters/3_supplementary.typ
+++ b/docs/chapters/3_supplementary.typ
@@ -1,0 +1,5 @@
+// Chapter 3: Supplementary Material
+
+= Supplementary Material
+
+This section contains supplementary material referenced in @sec:toplevel.

--- a/docs/hs3-defs.typ
+++ b/docs/hs3-defs.typ
@@ -1,0 +1,4 @@
+// Shared definitions for HS3 Typst document
+
+// SmallCaps helper
+#let sc(body) = text(features: ("smcp",), body)

--- a/hs3.typ
+++ b/hs3.typ
@@ -1,0 +1,92 @@
+// HS3 - HEP Statistics Serialization Standard
+// Central document file
+
+#set document(
+  title: [HS#super[3] v0.2.9],
+  author: (
+    "Carsten Burgard",
+    "Tomas Dado",
+    "Jonas Eschle",
+    "Matthew Feickert",
+    "Cornelius Grunwald",
+    "Alexander Held",
+    "Jerry Ling",
+    "Robin Pelkner",
+    "Jonas Rembser",
+    "Oliver Schulz",
+  ),
+  date: datetime(year: 2025, month: 9, day: 1),
+)
+
+#set page(
+  paper: "a4",
+  margin: (x: 2.5cm, y: 2.5cm),
+  numbering: "1",
+)
+
+#set text(font: "New Computer Modern", size: 11pt)
+#set par(justify: true)
+#set heading(numbering: "1.1.1.1")
+#set math.equation(numbering: "(1)")
+
+// Shared definitions
+#import "docs/hs3-defs.typ": sc
+
+// Title page
+#align(center)[
+  #v(3cm)
+  #text(size: 24pt, weight: "bold")[HS#super[3] v0.2.9]
+  #v(1cm)
+  #text(size: 12pt)[
+    Carsten Burgard, Tomas Dado, Jonas Eschle, Matthew Feickert, \
+    Cornelius Grunwald, Alexander Held, Jerry Ling, \
+    Robin Pelkner, Jonas Rembser, Oliver Schulz
+  ]
+  #v(0.5cm)
+  #text(size: 11pt)[2025-09-01]
+  #v(2cm)
+]
+
+// About section (unnumbered)
+#heading(level: 1, numbering: none)[About this document]
+
+#block(inset: (left: 1em))[
+  #image("docs/images/cc0.png", height: 1em) To the extent possible under law, the authors have waived all
+  copyright and related or neighboring rights to this document. For details,
+  please refer to the _Creative Commons_ `CC0` license @cc0.
+  This work is published from: CERN, Geneva.
+]
+
+// Include chapters
+#include "docs/chapters/1_introduction.typ"
+
+#include "docs/chapters/2_toplevels.typ"
+
+#include "docs/chapters/2.1_distributions.typ"
+
+#include "docs/chapters/2.1.1_fundamental_distributions.typ"
+
+#include "docs/chapters/2.1.2_composite_distributions.typ"
+
+#include "docs/chapters/2.2_functions.typ"
+
+#include "docs/chapters/2.3_data.typ"
+
+#include "docs/chapters/2.4_likelihoods.typ"
+
+#include "docs/chapters/2.5_domains.typ"
+
+#include "docs/chapters/2.6_parameter_points.typ"
+
+#include "docs/chapters/2.7_analyses.typ"
+
+#include "docs/chapters/2.8_metadata.typ"
+
+#include "docs/chapters/2.9_misc.typ"
+
+#include "docs/chapters/3_supplementary.typ"
+
+#include "docs/chapters/3.1_generic_expressions.typ"
+
+// Bibliography
+#bibliography("docs/hs3.bib", style: "ieee")


### PR DESCRIPTION
For now just an experiment to see if Typst would give us nicer math and PDF generation.

The main document `hs3.typ` compiles and looks correct, but no CI resp. automatic generation is set up yet. The Markdown files are sill present and untouched, for direct comparison.

Conversion of Markdown to Typst via Claude 4.5 Opus.
