### PR TITLE
Add function outputs and reference syntax.

### DIFF
--- a/docs/chapters/2.1_distributions.md
+++ b/docs/chapters/2.1_distributions.md
@@ -15,19 +15,25 @@ Each distribution [must]{.smallcaps} have the components `type`, denoting the ki
 	{ 
 		"name":"gauss1", 
 		"type":"gaussian_dist", 
-		"mean":1.0, 
+		"mean":"sum_1", 
 		"sigma":"param_sigma", 
-		"x":"param_x" 
+		"x":"data_x" 
 	}, 
 	{ 
 		"name":"exp1", 
 		"type":"exponential_dist", 
 		"c":-2, 
-		"x":"data_x" 
+		"x":"param_x" 
 	}, 
 	... 
 ] 
 ```
+
+The parameters of a distribution may refer to the output of functions via
+`function_name.output_name`. As a shorthand notation, when referring to the
+result of a single-output function, `function_name` may be used as an
+equivalent to `function_name.value`. So `"mean":"sum_1"` is equivalent to
+`"mean":"sum_1.value"`.
 
 Distributions can be treated either as `extended` or as non-`extended` [@barlow-extended-ml]. Some distributions are always extended, others can never be extended, yet others can be used in extended and non-extended scenarios and have a switch selecting between the two. An non-extended distribution is always normalized to the unity. An extended distribution, on the other hand, can yield values larger than unity, where the yield is interpreted as the number of predicted events. That is to say, the distribution is augmented by a factor that is a Poisson constraint term for the total number of events. 
 In the following, all distributions supported in HS${}^3$ v0.2.9 are listed in detail. Future versions will expand upon this list. 

--- a/docs/chapters/2.1_distributions.md
+++ b/docs/chapters/2.1_distributions.md
@@ -35,5 +35,13 @@ result of a single-output function, `function_name` may be used as an
 equivalent to `function_name.value`. So `"mean":"sum_1"` is equivalent to
 `"mean":"sum_1.value"`.
 
+The parameters of a distribution may also refer to variates of other
+distributions via `distribution_name.variate_name`. For example, if
+distribution `exp1` has a variate `x`, then the value of that variate can be
+referred to as `dist1.x`, e.g. `"sigma":"exp1.x"`, resulting in a hierarchical
+distribution (a folding of distributions). In the current version of this
+standard, this is an optional feature and may not be supported by all
+implementations. It may become mandatory in future versions.
+
 Distributions can be treated either as `extended` or as non-`extended` [@barlow-extended-ml]. Some distributions are always extended, others can never be extended, yet others can be used in extended and non-extended scenarios and have a switch selecting between the two. An non-extended distribution is always normalized to the unity. An extended distribution, on the other hand, can yield values larger than unity, where the yield is interpreted as the number of predicted events. That is to say, the distribution is augmented by a factor that is a Poisson constraint term for the total number of events. 
 In the following, all distributions supported in HS${}^3$ v0.2.9 are listed in detail. Future versions will expand upon this list. 

--- a/docs/chapters/2.2_functions.md
+++ b/docs/chapters/2.2_functions.md
@@ -35,6 +35,13 @@ equivalent to `function_name.value`. So
 `"summands" : [1.8, "sum_2", "param_xy"]` is equivalent to 
 `"summands" : [1.8, "sum_2.value", "param_xy"]`.
 
+The inputs of a function may also refer to variates of distributions via
+`distribution_name.variate_name`. So if  example, if a distribution `exp1` has
+a variate `x`, then the value of that variate can be referred to as `dist1.x`,
+e.g. `"summands" : [1.8, "exp1.x", "param_xy"]`. In the current version of
+this standard, this is an optional feature and may not be supported by all
+implementations. It may become mandatory in future versions.
+
 
 ### Product 
 A product of values or functions $a_i$. 

--- a/docs/chapters/2.2_functions.md
+++ b/docs/chapters/2.2_functions.md
@@ -36,7 +36,7 @@ equivalent to `function_name.value`. So
 `"summands" : [1.8, "sum_2.value", "param_xy"]`.
 
 The inputs of a function may also refer to variates of distributions via
-`distribution_name.variate_name`. So if  example, if a distribution `exp1` has
+`distribution_name.variate_name`. So for example, if a distribution `exp1` has
 a variate `x`, then the value of that variate can be referred to as `dist1.x`,
 e.g. `"summands" : [1.8, "exp1.x", "param_xy"]`. In the current version of
 this standard, this is an optional feature and may not be supported by all

--- a/docs/chapters/2.2_functions.md
+++ b/docs/chapters/2.2_functions.md
@@ -9,19 +9,32 @@ The top-level component `functions` describes an array of mathematical functions
 -   `name`: custom unique string 
 -   `type`: string that determines the kind of function, e.g. `sum` 
 -   `...`: each function has individual parameter keys for the various     individual parameters. For example, functions of type `sum` have the     parameter key `summands`. In general, these keys can describe     strings as references to other objects or numbers. Depending on the     parameter and the type of function, they appear either in single     item or array format. 
+-   `output`: label(s) the output(s) of the function. For single-output
+-   functions, this field is optional and set to `"value"` by default. A
+-   single output name (like `"output" : "value"`) and an array with a single output
+-   name (like `"output" : ["value"]`) are equivalent. For a function with
+-   multiple output values, `output` must be set to an array of names
+-   (like `"output" : ["a", "b", "c"]`).
 
 ```json title="Example: Functions"
 "functions": [ 
 	{ 
 		"name" : "sum1", 
 		"type" : "sum", 
-		"summands" : [1.8, 4, "param_xy"] 
+		"summands" : [1.8, "sum_2", "param_xy"],
+		"output" : "value"
 	}, 
 	... 
 ]
 ``` 
 
-In the following the implemented functions are described in detail. 
+The inputs of a function may refer to the output of other functions via
+`function_name.output_name`. As a shorthand notation, when referring to the
+result of a single-output function, `function_name` may be used as an
+equivalent to `function_name.value`. So
+`"summands" : [1.8, "sum_2", "param_xy"]` is equivalent to 
+`"summands" : [1.8, "sum_2.value", "param_xy"]`.
+
 
 ### Product 
 A product of values or functions $a_i$. 


### PR DESCRIPTION
This PR unifies the role of the name for functions and distributions. It also provides the necessary basis for multiple-output functions and hierarchical models.

In the future, when adding support for vector-values, we can then also allow `"function_name.output_name[index]"` and `"distribution_name.variate_name[index]"`.