### PR TITLE
readme: arXiv link and citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ construction and open to discussion**
 
 # Preprint and Citation
 
-We now have a preprint paper: https://arxiv.org/abs/2606.01760v2
+We now have a preprint paper: https://arxiv.org/abs/2606.01760
 
 If you use HS3 in your work please cite as:
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ working group and not yet a standard.**
 **Everything, including naming, folder structure etc is under
 construction and open to discussion**
 
+# Preprint and Citation
+
+We now have a preprint paper: https://arxiv.org/abs/2606.01760v2
+
+If you use HS3 in your work please cite as:
+
+```
+@article{hs3preprint,
+  title={HS3: A Descriptive, Interoperable Serialization Standard for Statistical Models in High-Energy Physics},
+  author={Burgard, Carsten and Schulz, Oliver and Stark, Giordon and Rembser, Jonas and Cello, Simon and Grunwald, Cornelius},
+  journal={arXiv preprint arXiv:2606.01760},
+  year={2026}
+}
+```
 
 # In short
 
@@ -15,12 +29,12 @@ The HEP Statistics Serialization Standard (HS3) defines standards of
 different statistical procedures and results used in High Energy Physics
 (HEP) in terms of human-and machine readable representations. Different
 versions are defined with specifications and semantics that are
-acknowledged by a committee. 
+acknowledged by a committee.
 
 View the current draft of the HS3 standard here: https://hep-statistics-serialization-standard.github.io/
 
 Corresponding implementations to check the
-validity of files are also provided, at a *best effort* basis.
+validity of files are also provided, at a _best effort_ basis.
 More information can be found in the corresponding projects.
 
 # Why
@@ -28,13 +42,13 @@ More information can be found in the corresponding projects.
 There are two main motivation to have a code-independent representation
 of the likelihood and inference results.
 
--   It allows to publish the likelihood; a long-term goal in High Energy
-    Physics experiments.
+- It allows to publish the likelihood; a long-term goal in High Energy
+  Physics experiments.
 
 - A framework- and language independent representation allows to use
-different frameworks interchangeably; at least for reasonable
-complicated cases. It removes the dependency on code and reduces the
-need for maintenance of legacy projects.
+  different frameworks interchangeably; at least for reasonable
+  complicated cases. It removes the dependency on code and reduces the
+  need for maintenance of legacy projects.
 
 # Goal
 


### PR DESCRIPTION
As HS3 now has a preprint paper, we should link this paper with a citation. I have added this to the README.md. Please feel free to comment on wording and positioning; right now it is rather terse and positioned near the top. I have also seen them positioned at the foot of the README. 