### PR TITLE
Add filename extension recommendation

### DIFF
--- a/docs/chapters/1_introduction.md
+++ b/docs/chapters/1_introduction.md
@@ -71,7 +71,9 @@ All `struct`s defining functions, distributions, parameters, variables, domains,
 Within most top-level `component`s, any one `string` given as a value to any component [should]{.smallcaps} refer to the `name` of another `object`, unless explicitly stated otherwise. Top-level `component`s in which this is not the case are explicitly marked as such. 
 
 ## File format 
-HS${}^3$ documents are encoded in the JSON format as defined in ISO/IEC 21778:2017 [@json]. Implementations [may]{.smallcaps} support other serialization formats that support a non-ambiguous mapping to JSON, such as TOML or YAML, in which case they [should]{.smallcaps} use a different file extension. 
+HS${}^3$ documents are encoded in the JSON format as defined in ISO/IEC 21778:2017 [@json]. Implementations [may]{.smallcaps} support other serialization formats that support a non-ambiguous mapping to JSON, such as TOML or YAML, in which case they [should]{.smallcaps} use a different file extension.
+
+The recommended filename extension for HS${}^3$ JSON documents is `.hs3.json`.
 
 ## Validators 
 Future versions of this standard will recommend official validator implementations and schemata. Currently, these have not been finalized. 


### PR DESCRIPTION
I think it would be helpful to recommend a file extension for HS3 files. We want `.json` at the end to make model files easily accessible to the wealth of JSON tooling out there (including syntax highlighting in editors, etc.). But it would also be really helpful if the content type could be inferred from the file extension, so more specialized tooling can automatically do the right thing.

So I propose that we recommend (not require) the extension `*.hs3.json` for HS3 JSON files.

Consider this, for example:

```
some_convert_tool input.pyhf.json output.hs3.json

some_convert_tool input.hs3.json <some_other_model_format_file>
```

Without file extensions that are more specific than `.json`, the conversion tool cannot infer the output format. And the tool would have to introspect the input file first to detect the input format, before deciding which internal tooling to route the conversion to. Of course such a conversion tool would likely also have an option to set input and output format explicitly - but an auto-detect is very user-friendly. And very useful for automated conversion toolschains as well.

It would also be very helpful to users if they can see that a JSON file has "HS3 inside" immediately.

Double file endings are quite common in the JSON world, so I there is ample precedent:

- `*.schema.json`: JSON Schema documents
- `tsconfig.*.json`: TypeScript `tsconfig.base.json`, `tsconfig.build.json` ...
- `*.tokens.json`: W3C Design Tokens 
- `markdown.tmLanguage.json`: TextMate syntax grammar serialized as JSON
- ...