### PR TITLE
Documentation for added RF classes

### DIFF
--- a/docs/chapters/2.1.1_fundamental_distributions.md
+++ b/docs/chapters/2.1.1_fundamental_distributions.md
@@ -53,6 +53,26 @@ Asimov datasets [@asymptotics].
 -   `mean`: value or name of the parameter used as mean $\lambda$. 
 
 
+#### Chebychev distribution
+
+The Chebychev distribution is defined as a polynomial in Chebychev polynomials of the first kind:
+
+$$
+\begin{aligned}
+\text{ChebychevPdf}(x, a_1,\ldots,a_n) =
+\frac{1}{\ensuremath{\mathcal{M}}}\left(T_0(z) + \sum_{i=1}^{n} a_i T_i(z)\right),
+\quad z = 2\frac{x-x_{\min}}{x_{\max}-x_{\min}} - 1 .
+\end{aligned}
+$$
+
+The coefficient of the constant term $T_0(z)=1$ is implicit and fixed to one.
+
+-   `name`: custom unique string
+-   `type`: `chebychev_dist`
+-   `x`: name of the variable $x$
+-   `coefficients`: array of coefficients $a_i$ for the non-constant Chebychev terms. The first coefficient belongs to $T_1(z)$.
+
+
 #### Uniform distribution
 
 The continuous uniform distribution is defined as: 
@@ -101,6 +121,38 @@ The keys are
 -   `sigma`: value or names of $\sigma_L$ and $\sigma_R$ from above.     [must not]{.smallcaps} be used in conjuction with `sigma_L` or     `sigma_R`. 
 -   `sigma_L`: value or names of $\sigma_L$ from above. [must     not]{.smallcaps} be used in conjuction with `sigma`. 
 -   `sigma_R`: value or names of $\sigma_R$ from above. [must     not]{.smallcaps} be used in conjuction with `sigma`. 
+
+
+#### Decay distribution
+
+The decay distribution describes a single- or double-sided exponential decay convolved with a resolution model $R$:
+
+$$
+\begin{aligned}
+\text{DecayPdf}(t,\tau,R) =
+\frac{1}{\ensuremath{\mathcal{M}}}\,(B_{\text{type}} * R)(t),
+\end{aligned}
+$$
+
+where
+
+$$
+\begin{aligned}
+B_{\text{type}}(t) =
+\begin{cases}
+\exp(-t/\tau), & \text{for SingleSided}, \\
+\exp(t/\tau), & \text{for Flipped}, \\
+\exp(-|t|/\tau), & \text{for DoubleSided}.
+\end{cases}
+\end{aligned}
+$$
+
+-   `name`: custom unique string
+-   `type`: `decay_dist`
+-   `t`: name of the decay-time variable $t$
+-   `tau`: value or name of the decay constant $\tau$
+-   `resolutionModel`: name of the resolution model $R$
+-   `decayType`: integer selecting the decay basis, with `0` for `SingleSided`, `1` for `DoubleSided`, and `2` for `Flipped`.
 
 
 #### Exponential distribution

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -37,6 +37,33 @@ $$
 $$
 
 
+#### Mixture model
+
+The mixture model is a weighted sum of resolution models or model PDFs:
+
+$$
+\begin{aligned}
+\text{MixtureModel}(x) = \sum_{i=1}^{n} c_i\,m_i(x).
+\end{aligned}
+$$
+
+If one coefficient fewer than the number of summands is provided, the final coefficient is computed as
+
+$$
+\begin{aligned}
+c_n = 1 - \sum_{i=1}^{n-1} c_i .
+\end{aligned}
+$$
+
+If all coefficients are given, their sum is used as the expected number of events in extended use cases.
+
+-   `name`: custom unique string
+-   `type`: `mixture_model`
+-   `summands`: array of names referencing model distributions
+-   `coefficients`: array of names of coefficients $c_i$ or numbers
+-   `extended`: boolean denoting whether this is an extended model
+
+
 #### Product distribution {#sec:product-distribution label="sec:product-distribution"} 
 
 The product of independent distributions $f_i$ is defined as 
@@ -53,6 +80,24 @@ $$
 -   `type`: `product_dist` 
 -   `x`: name of the variable $x$ ([optional]{.smallcaps}, since the     variable is fully defined by the factors) 
 -   `factors`: array of names referencing distributions 
+
+#### Efficiency product distribution
+
+The efficiency product distribution multiplies a normalized PDF with an efficiency function and normalizes the product:
+
+$$
+\begin{aligned}
+\text{EfficiencyProductPdf}(x) =
+\frac{1}{\ensuremath{\mathcal{M}}}\, f(x)\,\epsilon(x).
+\end{aligned}
+$$
+
+The efficiency function is expected to be non-negative over the domain.
+
+-   `name`: custom unique string
+-   `type`: `efficiency_product_pdf_dist`
+-   `pdf`: name of the input distribution $f$
+-   `eff`: name of the efficiency function $\epsilon$
 
 #### Density Function distribution 
 

--- a/docs/chapters/2.2_functions.md
+++ b/docs/chapters/2.2_functions.md
@@ -49,6 +49,74 @@ $$
 -   `type`: `sum` 
 -   `summands`: array of names of the elements of the sum or numbers. 
 
+### Polynomial Function
+The polynomial function is defined as
+
+$$
+\begin{aligned}
+\text{Polynomial}(x, a_0, a_1,\ldots,a_n) = \sum_{i=0}^{n} a_i x^i .
+\end{aligned}
+$$
+
+Unlike `polynomial_dist`, this object is a function and is not normalized.
+
+-   `name`: custom unique string
+-   `type`: `polynomial`
+-   `x`: name of the variable $x$
+-   `coefficients`: array of coefficients $a_i$. The length of this array implies the degree of the polynomial.
+
+### Derivative Function
+The derivative function represents a numerical derivative of another function with respect to a variable:
+
+$$
+\begin{aligned}
+\text{Derivative}(f,x,n) = \frac{d^n f}{dx^n}.
+\end{aligned}
+$$
+
+The order is intended for first, second, or third derivatives, and `eps` controls the finite-difference step size.
+
+-   `name`: custom unique string
+-   `type`: `derivative`
+-   `function`: name of the function $f$
+-   `x`: name of the differentiation variable $x$
+-   `order`: derivative order $n$
+-   `eps`: step size used for the numerical derivative
+-   `normalization`: array of names defining the normalization set ([optional]{.smallcaps})
+
+### Gaussian Resolution Model
+The Gaussian resolution model represents a Gaussian smearing model in the convolution variable $x$:
+
+$$
+\begin{aligned}
+\text{GaussModel}(x,\mu,\sigma) =
+\frac{1}{\sigma\sqrt{2\pi}}\exp\left(-\frac{(x-\mu)^2}{2\sigma^2}\right).
+\end{aligned}
+$$
+
+It can be used as a resolution model for analytical convolutions.
+
+-   `name`: custom unique string
+-   `type`: `gauss_model_function`
+-   `x`: name of the convolution variable $x$
+-   `mean`: value or name of the mean parameter $\mu$
+-   `sigma`: value or name of the width parameter $\sigma$
+
+### Truth Resolution Model
+The truth resolution model corresponds to perfect resolution, represented by a delta function in the convolution variable:
+
+$$
+\begin{aligned}
+\text{TruthModel}(x) = \delta(x).
+\end{aligned}
+$$
+
+When used in an analytical convolution, it returns the unconvolved basis function.
+
+-   `name`: custom unique string
+-   `type`: `truth_model_function`
+-   `x`: name of the convolution variable $x$
+
 ### Generic Function 
 *Note: Users should prefer the specific functions defined in this standard over generic functions where possible, as implementations of these will typically be more optimized. Generic functions should only be used if no equivalent specific distribution is defined.* 
 A generic function is defined by an expression. The expression must be a valid HS<sup>3</sup>-expression string (see Section 


### PR DESCRIPTION
This PR includes documentation for some new classes from the RooFit tutorial at https://root.cern/doc/master/group__tutorial__roofit__main.html 
